### PR TITLE
allow some X hets in males, denovo imprinted, exome only CNV false po…

### DIFF
--- a/clinicalfilter/inheritance.py
+++ b/clinicalfilter/inheritance.py
@@ -341,6 +341,12 @@ class Autosomal(Inheritance):
                     'Imprinted' in self.known_gene['inh']:
                 self.log_string = 'possible imprinted variant'
                 return "single_variant"
+            elif (self.dad.is_hom_ref() or self.mom.is_hom_ref()) and \
+                    self.child.is_lof() and self.known_gene is not None and \
+                    'Imprinted' in self.known_gene['inh']:
+#allow de novo variants in imprinted genes
+                self.log_string = 'possible imprinted de novo variant'
+                return "single_variant"
         
         if self.mom.is_hom_ref() and self.dad.is_hom_ref():
             self.log_string = "de novo as {0}".format(report)

--- a/clinicalfilter/ped.py
+++ b/clinicalfilter/ped.py
@@ -122,6 +122,14 @@ class Person(object):
             raise ValueError(self.person_id + " is listed as gender " + \
                 self.get_gender() + ", which differs from the sex expected " + \
                 "as a parent)")
+
+    def has_parents(self):
+        """returns True/False for does the person have two parents
+        """
+        if self.mom_id == '0' or self.dad_id == '0':
+            return False
+        else:
+            return True
     
     def __gt__(self, other):
         """ implement greater than check, for sorting children in a Family

--- a/clinicalfilter/utils.py
+++ b/clinicalfilter/utils.py
@@ -118,7 +118,7 @@ def exclude_header(vcf):
     
     vcf.seek(current_pos)
 
-def construct_variant(line, gender, mnvs=None, sum_x_lr2=None):
+def construct_variant(line, gender, mnvs=None, sum_x_lr2=None, parents=None):
     """ constructs a Variant object for a VCF line, specific to the variant type
     
     Args:
@@ -129,6 +129,7 @@ def construct_variant(line, gender, mnvs=None, sum_x_lr2=None):
             (eg "1" or "M" for male, "2", or "F" for female).
         mnvs: dictionary
         sum_x_lr2: Sum of mean l2r on X chromosome for probands
+        parents: does the proband have parents?
     
     Returns:
         returns a Variant object
@@ -146,7 +147,7 @@ def construct_variant(line, gender, mnvs=None, sum_x_lr2=None):
         mnv_code = mnvs[(chrom, int(pos))]
     
     var = Var(chrom, pos, var_id, ref, alt, qual, filter_val, info, keys,
-        sample, gender, sum_x_lr2, mnv_code=mnv_code)
+        sample, gender, sum_x_lr2, parents, mnv_code=mnv_code)
     
     if var.is_cnv():
         var.fix_gene_IDs()

--- a/clinicalfilter/variant/cnv.py
+++ b/clinicalfilter/variant/cnv.py
@@ -167,11 +167,15 @@ class CNV(Variant):
         Returns:
             inheritance state as string e.g 'maternal', 'paternal' etc
         '''
+
+#        print(self.__dict__)
+#        exit(0)
         
         if self.format is None:
             return None
         
         inh = []
+
         for key in ['INHERITANCE', 'CIFER_INHERITANCE']:
             if key in self.format:
                 inh.append(self.format[key])

--- a/clinicalfilter/variant/cnv.py
+++ b/clinicalfilter/variant/cnv.py
@@ -168,9 +168,6 @@ class CNV(Variant):
             inheritance state as string e.g 'maternal', 'paternal' etc
         '''
 
-#        print(self.__dict__)
-#        exit(0)
-        
         if self.format is None:
             return None
         

--- a/clinicalfilter/variant/cnv_exome_filter.py
+++ b/clinicalfilter/variant/cnv_exome_filter.py
@@ -32,6 +32,7 @@ class ExomeCNV(object):
         """ filters the CNV
         """
         passes = True
+ 
         if self.fails_convex_score():
             passes = False
             if track_variant:
@@ -52,6 +53,7 @@ class ExomeCNV(object):
             passes = False
             if track_variant:
                 print("failed commonforwards", self.cnv.info["COMMONFORWARDS"])
+#        elif self.cnv.has_parents and self.fails_cifer_inh():#may be able to use self.cnv.get_has_parents and remove parents above
         elif self.fails_cifer_inh():
             passes = False
             if track_variant:
@@ -126,8 +128,10 @@ class ExomeCNV(object):
     def fails_cifer_inh(self):
         """ check that the CIFER inheritance classification isn't false_positive
         """
-        
-        return self.cnv.format["CIFER_INHERITANCE"] == "false_positive"
+        if self.cnv.get_has_parents():
+            return self.cnv.format["CIFER_INHERITANCE"] == "false_positive"
+        else:
+            return False
 
     def fails_x_lr2(self):
         """Fail if call is on X chromosome and sum of mean l2r on X is <-5000 

--- a/clinicalfilter/variant/snv.py
+++ b/clinicalfilter/variant/snv.py
@@ -68,12 +68,8 @@ class SNV(Variant):
             raise ValueError("cannot find a genotype")
         
         self.set_reference_genotypes()
-#        print(self.__dict__)
-#        print("\n")
         self.convert_genotype_code_to_alleles()
-#        print(self.__dict__)
-#        print(self.alleles)
-#        exit(0)
+
     
     def convert_genotype(self, genotype):
         """Maps genotypes from two character format to single character.

--- a/clinicalfilter/variant/variant.py
+++ b/clinicalfilter/variant/variant.py
@@ -39,7 +39,7 @@ class Variant(object):
         cls_obj.known_genes = known_genes
     
     def __init__(self, chrom, position, id, ref, alts, qual, filter, info=None,
-            format=None, sample=None, gender=None, sum_x_lr2=None, mnv_code=None):
+            format=None, sample=None, gender=None, sum_x_lr2=None, parents=None, mnv_code=None):
         """ initialise the object with the definition values
         """
         
@@ -58,7 +58,9 @@ class Variant(object):
         self.filter = filter
 
         self.sum_x_lr2 = sum_x_lr2
-        
+
+        self.has_parents = parents
+         
         # intialise variables that will be set later
         self.inheritance_type = None
         
@@ -302,3 +304,9 @@ class Variant(object):
         """
 
         return self.sum_x_lr2
+
+    def get_has_parents(self):
+        """returns false for singletons, true for trios
+        """
+        
+        return self.has_parents

--- a/tests/test_inheritance.py
+++ b/tests/test_inheritance.py
@@ -165,11 +165,13 @@ class TestInheritancePy(unittest.TestCase):
         self.assertEqual(self.inh.get_candidate_variants(),
             [(var, ['single_variant'], ['Imprinted'], ['TEST'])])
         
-        # de novos shouldn't pass the imprinted route
+        # de novos should now pass the imprinted route
         var = self.create_variant(position='150', cq='stop_gained',
             geno=['0/1', '0/0', '0/0'])
         self.inh = Autosomal([var], self.trio, inh, "TEST")
-        self.assertEqual(self.inh.get_candidate_variants(), [])
+        #self.assertEqual(self.inh.get_candidate_variants(), [])
+        self.assertEqual(self.inh.get_candidate_variants(),
+            [(var, ['single_variant'], ['Imprinted'], ['TEST'])])
         
         # check a variant that shouldn't pass the imprinted route due to there
         # not being a known gene.

--- a/tests/test_variant_cnv_exome_filter.py
+++ b/tests/test_variant_cnv_exome_filter.py
@@ -214,6 +214,20 @@ class TestExomeCnvPy(unittest.TestCase):
         self.var.cnv.info["CONVEXSCORE"] = "20"
         self.assertFalse(self.var.fails_additional_filters())
 
+    def test_fails_cifer_inh(self):
+        """test that CNVs in non-trios aren't filtered out on cifer false pos
+        but those in trios are filtered out
+        """
+        self.var.cnv.has_parents = True
+        self.var.cnv.format["CIFER_INHERITANCE"] = "false_positive"
+        self.assertTrue(self.var.fails_cifer_inh())
+
+        self.var.cnv.has_parents = False
+        self.var.cnv.format["CIFER_INHERITANCE"] = "false_positive"
+        self.assertFalse(self.var.fails_cifer_inh())
+
+
+
         
 
 if __name__ == '__main__':

--- a/tests/test_variant_snv.py
+++ b/tests/test_variant_snv.py
@@ -168,6 +168,28 @@ class TestVariantSnvPy(unittest.TestCase):
             self.var.format["GT"] = genotype
             self.var.set_genotype()
             self.assertEqual(self.var.get_genotype(), result)
+
+    def test_set_allosomal_male(self):
+        """test that convert_allosomal_genotype_code_to_alleles handles hets in
+        male correctly
+        """
+        self.var._set_gender("male")
+        self.var.chrom = 'X'
+        self.var.genotype = '1'
+        #treat as hom if VAF > 0.8
+        self.var.format["AD"] = '1,19'
+        self.var.format["GT"] = '1/1'
+        self.var.convert_allosomal_genotype_code_to_alleles()
+
+        self.assertEqual(self.var.alleles, set([self.var.alt_alleles]))
+        
+        #treat as hom if denovo
+        self.var.format["AD"] = '10,19'
+        self.var.format["PP_DNM"] = 0.0099
+        self.var.convert_allosomal_genotype_code_to_alleles()
+
+        self.assertEqual(self.var.alleles, set([self.var.alt_alleles]))       
+
     
     def test_is_het_autosomal(self):
         """ tests that is_het() operates correctly for automsal chromosomes


### PR DESCRIPTION
…s inheritence in singletons

A couple of changes I was working on last year:
1 - allow some SNPs in male X which are called as hets - those which are denovos or have variant allele fraction >0.8 are kept and are treated as homs for the clinical filtering
2 - allow denovo variants on imprinted genes through

A more recent change:
3 - exome only CNVs fail if cifer prediction is false positive, which is fine for trios but in singletons the majority of cifer predictions are false positive, so this prevents exome only CNVs from singletons coming through clinical filtering. So disabling this filter in non-trios for now